### PR TITLE
Fix: add chunking strategy to WebsiteReader initialization

### DIFF
--- a/libs/agno/agno/document/reader/website_reader.py
+++ b/libs/agno/agno/document/reader/website_reader.py
@@ -26,8 +26,8 @@ class WebsiteReader(Reader):
 
     max_depth: int = 3
     max_links: int = 10
-    bad_fragment: str = ''
-    bad_paths: list[str] = []
+    bad_fragment: str = ""
+    bad_path: str = ""
 
     _visited: Set[str] = field(default_factory=set)
     _urls_to_crawl: List[Tuple[str, int]] = field(default_factory=list)
@@ -121,8 +121,9 @@ class WebsiteReader(Reader):
                 or not urlparse(current_url).netloc.endswith(primary_domain)
                 or current_depth > self.max_depth
                 or num_links >= self.max_links
-                or parsed.fragment and self.bad_fragment in parsed.fragment
-                or parsed.path in self.bad_paths
+                or parsed.fragment
+                and self.bad_fragment in parsed.fragment
+                or self.bad_path in parsed.path
             ):
                 continue
 

--- a/libs/agno/agno/knowledge/website.py
+++ b/libs/agno/agno/knowledge/website.py
@@ -16,17 +16,19 @@ class WebsiteKnowledgeBase(AgentKnowledge):
     # WebsiteReader parameters
     max_depth: int = 3
     max_links: int = 10
-    bad_fragment: str = ''
-    bad_paths: list[str] = []
+    bad_fragment: str = "#"
+    bad_path: str = ""
 
     @model_validator(mode="after")
     def set_reader(self) -> "WebsiteKnowledgeBase":
         if self.reader is None:
-            self.reader = WebsiteReader(max_depth=self.max_depth,
-                                        max_links=self.max_links,
-                                        bad_fragment=self.bad_fragment,
-                                        bad_paths=self.bad_paths,
-                                        chunking_strategy=self.chunking_strategy,)
+            self.reader = WebsiteReader(
+                max_depth=self.max_depth,
+                max_links=self.max_links,
+                bad_fragment=self.bad_fragment,
+                bad_path=self.bad_path,
+                chunking_strategy=self.chunking_strategy,
+            )
         return self
 
     @property


### PR DESCRIPTION
This pull request includes a small change to the `libs/agno/agno/knowledge/website.py` file. The change involves adding the `chunking_strategy` parameter to the `WebsiteReader` initialization in the `set_reader` method.

Change in `set_reader` method:

* [`libs/agno/agno/knowledge/website.py`](diffhunk://#diff-6b539f164bee3694ba4e251025dc22212ceae6836609cf6e9d7f87879928542fL28-R29): Added the `chunking_strategy` parameter to the `WebsiteReader` initialization.