### PR TITLE
Merge remote-tracking branch 'upstream/main' into fix-chunking-strategy

### DIFF
--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -114,13 +114,16 @@ class RunResponse:
             )
 
         if self.images is not None:
-            _dict["images"] = [img.model_dump(exclude_none=True) for img in self.images]
+            _dict["images"] = [img.model_dump(exclude_none=True) for img in self.images if isinstance(img, BaseModel)]
+            _dict["images"] += [img for img in self.images if isinstance(img, dict)]
 
         if self.videos is not None:
-            _dict["videos"] = [vid.model_dump(exclude_none=True) for vid in self.videos]
+            _dict["videos"] = [vid.model_dump(exclude_none=True) for vid in self.videos if isinstance(vid, BaseModel)]
+            _dict["videos"] += [vid for vid in self.videos if isinstance(vid, dict)]
 
         if self.audio is not None:
-            _dict["audio"] = [aud.model_dump(exclude_none=True) for aud in self.audio]
+            _dict["audio"] = [aud.model_dump(exclude_none=True) for aud in self.audio if isinstance(aud, BaseModel)]
+            _dict["audio"] += [aud for aud in self.audio if isinstance(aud, dict)]
 
         if self.response_audio is not None:
             _dict["response_audio"] = (


### PR DESCRIPTION
This pull request includes changes to the `to_dict` method in the `libs/agno/agno/run/response.py` file to handle different types of objects in the `images`, `videos`, and `audio` attributes more robustly. The update ensures that both `BaseModel` instances and dictionaries are processed correctly.

Key changes include:

* [`libs/agno/agno/run/response.py`](diffhunk://#diff-1f0206ecb0a5cb833fd76b58d21f06cc340e93691a0853693de97cbb26457ef1L117-R126): Modified the `to_dict` method to handle `BaseModel` instances and dictionaries separately for the `images`, `videos`, and `audio` attributes. This change ensures that all valid objects are included in the resulting dictionary.