### PR TITLE
Refactor WebsiteKnowledgeBase defaults and imports

### DIFF
--- a/libs/agno/agno/document/reader/website_reader.py
+++ b/libs/agno/agno/document/reader/website_reader.py
@@ -31,13 +31,25 @@ class WebsiteReader(Reader):
     _urls_to_crawl: List[Tuple[str, int]] = field(default_factory=list)
 
     def __init__(
-        self, max_depth: int = 3, max_links: int = 10, timeout: int = 10, proxy: Optional[str] = None, **kwargs
+        self,
+        max_depth: int = 3,
+        max_links: int = 10,
+        timeout: int = 10,
+        proxy: Optional[str] = None,
+        bad_fragment: str = "",
+        bad_path: str = "",
+        base_url: str = "",
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.max_depth = max_depth
         self.max_links = max_links
         self.proxy = proxy
         self.timeout = timeout
+
+        self.bad_fragment = bad_fragment
+        self.bad_path = bad_path
+        self.base_url = base_url
 
         self._visited = set()
         self._urls_to_crawl = []

--- a/libs/agno/agno/knowledge/website.py
+++ b/libs/agno/agno/knowledge/website.py
@@ -25,9 +25,9 @@ class WebsiteKnowledgeBase(AgentKnowledge):
             self.reader = WebsiteReader(
                 max_depth=self.max_depth,
                 max_links=self.max_links,
+                chunking_strategy=self.chunking_strategy,
                 bad_fragment=self.bad_fragment,
                 bad_path=self.bad_path,
-                chunking_strategy=self.chunking_strategy,
                 base_url=self.base_url,
             )
         return self

--- a/libs/agno/agno/knowledge/website.py
+++ b/libs/agno/agno/knowledge/website.py
@@ -1,12 +1,11 @@
 import asyncio
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
-from pydantic import model_validator
-
 from agno.document import Document
 from agno.document.reader.website_reader import WebsiteReader
 from agno.knowledge.agent import AgentKnowledge
 from agno.utils.log import log_debug, log_info, logger
+from pydantic import model_validator
 
 
 class WebsiteKnowledgeBase(AgentKnowledge):
@@ -16,7 +15,7 @@ class WebsiteKnowledgeBase(AgentKnowledge):
     # WebsiteReader parameters
     max_depth: int = 3
     max_links: int = 10
-    bad_fragment: str = "#"
+    bad_fragment: str = ""
     bad_path: str = ""
     base_url: str = ""
 


### PR DESCRIPTION
Update the default value of `bad_fragment` in the `WebsiteKnowledgeBase` class and reorder import statements for better organization.